### PR TITLE
fix: prevent history_source_length from being undefined in batch mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+wandb
+*.pyc
+*.log

--- a/evaluate/streaming_eval.py
+++ b/evaluate/streaming_eval.py
@@ -154,10 +154,11 @@ def main():
         target_txt_lt.extend(target_txt)
         output_text_lt.extend([output_text,])
 
-        output_text_len = len(output_text.split())
-        al, laal = calculate_al_and_laal(len(_lengths[0]['source_seg_len'])-1, output_text_len, wait_lagging[:output_text_len])
-        AL.append(al)
-        LAAL.append(laal)
+        if inference_mode == "streaming":
+            output_text_len = len(output_text.split())
+            al, laal = calculate_al_and_laal(len(_lengths[0]['source_seg_len'])-1, output_text_len, wait_lagging[:output_text_len])
+            AL.append(al)
+            LAAL.append(laal)
 
 
         if accelerator.is_main_process:
@@ -165,13 +166,14 @@ def main():
             print("streaming-output:\n", output_text)
 
 
-    avg_LAAL = sum(LAAL) / len(LAAL)
-    avg_AL = sum(AL) / len(AL)
     bleu = sacrebleu.corpus_bleu(output_text_lt, [target_txt_lt])
-
     logging.info(f"BLEU score: {bleu.score:.2f}")
-    logging.info(f"all_AL score: {avg_AL:.2f}")
-    logging.info(f"all_LAAL score: {avg_LAAL:.2f}")
+    
+    if inference_mode == "streaming":
+        avg_LAAL = sum(LAAL) / len(LAAL)
+        avg_AL = sum(AL) / len(AL)
+        logging.info(f"all_AL score: {avg_AL:.2f}")
+        logging.info(f"all_LAAL score: {avg_LAAL:.2f}")
 
 
 if __name__ == "__main__":

--- a/models/Gemma2/gemma2_streaming.py
+++ b/models/Gemma2/gemma2_streaming.py
@@ -782,6 +782,11 @@ class Gemma2Model_stream(Gemma2Model):
 
         else:
             if generate_mode == 'batch':
+                if past_key_values is not None and len(past_key_values) > 0:
+                    history_source_length = past_key_values[0][0].shape[-2]
+                else:
+                    history_source_length = 0
+                current_length = history_source_length + inputs_embeds.shape[1]
                 cache_position = torch.arange(history_source_length, current_length, dtype=torch.long, device=cache_position.device)
                 causal_mask = self._update_causal_mask(
                     attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions

--- a/models/Llama3/llama_streaming.py
+++ b/models/Llama3/llama_streaming.py
@@ -812,6 +812,11 @@ class LlamaModel_stream(LlamaModel):
 
         else:
             if generate_mode == 'batch':
+                if past_key_values is not None and len(past_key_values) > 0:
+                    history_source_length = past_key_values[0][0].shape[-2]
+                else:
+                    history_source_length = 0
+                current_length = history_source_length + inputs_embeds.shape[1]
                 cache_position = torch.arange(history_source_length, current_length, dtype=torch.long, device=cache_position.device)
                 causal_mask = self._update_causal_mask(
                     attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions

--- a/models/Qwen2_5/qwen_streaming.py
+++ b/models/Qwen2_5/qwen_streaming.py
@@ -857,6 +857,11 @@ class Qwen2Model_stream(Qwen2Model):
 
         else:
             if generate_mode == 'batch':
+                if past_key_values is not None and len(past_key_values) > 0:
+                    history_source_length = past_key_values[0][0].shape[-2]
+                else:
+                    history_source_length = 0
+                current_length = history_source_length + inputs_embeds.shape[1]
                 cache_position = torch.arange(history_source_length, current_length, dtype=torch.long, device=cache_position.device)
                 causal_mask = self._update_causal_mask(
                     attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions


### PR DESCRIPTION
- Updated streaming generate logic in Gemma2, Llama3, and Qwen2_5 models
- Modified streaming_eval.py to avoid crashes in batch inference mode
- Added .gitignore file to ignore local cache and temp files